### PR TITLE
Fixed error on optional string parameters

### DIFF
--- a/example/OcelotOrleans.AspNetCore/OcelotOrleans.AspNetCore.csproj
+++ b/example/OcelotOrleans.AspNetCore/OcelotOrleans.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="2.2.4" />
     <PackageReference Include="Microsoft.Orleans.OrleansConsulUtils" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/Ocelot.OrleansHttpGateway/Requester/DefaultParameterBinder.cs
+++ b/src/Ocelot.OrleansHttpGateway/Requester/DefaultParameterBinder.cs
@@ -31,6 +31,12 @@ namespace Ocelot.OrleansHttpGateway.Requester
                 {
                     var param = parameters[i];
                     object value = null;
+                    
+                    if (param.IsOptional && !routeValues.Querys.Keys.Contains(param.Name))
+                    {
+                        continue;
+                    }
+
                     if (param.ParameterType.CanHaveChildren())
                     {
                         value = this.BindClassType(param, routeValues.Body);
@@ -46,6 +52,7 @@ namespace Ocelot.OrleansHttpGateway.Requester
                                 return new object[0];
                         }
                     }
+                    
 
                     result[i] = value;
                 }
@@ -67,6 +74,7 @@ namespace Ocelot.OrleansHttpGateway.Requester
             }
             else
             {
+                if (parameter.ParameterType.Equals(typeof(string))) return null;
                 return this.BindClassType(parameter, bodyData);
             }
         }


### PR DESCRIPTION
Ocelot was throwing json deserialize error if there is a optional string parameter witch is not in rest query